### PR TITLE
Improve ASCII test tool device resolution

### DIFF
--- a/cmd/test_ascii/main.go
+++ b/cmd/test_ascii/main.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/rjboer/GoSDR/internal/connectionmgr"
+	"github.com/rjboer/GoSDR/internal/sdrxml"
 )
 
 // loggingConn wraps a net.Conn and dumps every byte that crosses the wire.
@@ -42,12 +44,42 @@ func (c *loggingConn) Write(p []byte) (int, error) {
 	return n, err
 }
 
+// deriveInputMask builds a channel mask from input scan elements in the order of
+// their scan indexes. This mirrors how libiio composes masks for buffer
+// operations.
+func deriveInputMask(dev *sdrxml.DeviceEntry) (string, bool) {
+	var mask uint64
+	for _, ch := range dev.Channel {
+		if !strings.EqualFold(ch.Type, "input") || ch.ScanElementRaw == nil {
+			continue
+		}
+
+		idx, err := strconv.Atoi(ch.ScanElementRaw.Index)
+		if err != nil {
+			log.Printf("[WARN] skipping channel %q: invalid scan index %q: %v", ch.ID, ch.ScanElementRaw.Index, err)
+			continue
+		}
+		if idx < 0 || idx >= strconv.IntSize {
+			log.Printf("[WARN] skipping channel %q: scan index %d out of range", ch.ID, idx)
+			continue
+		}
+
+		mask |= 1 << idx
+	}
+
+	if mask == 0 {
+		return "", false
+	}
+
+	return fmt.Sprintf("%x", mask), true
+}
+
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
 
 	uri := flag.String("uri", "127.0.0.1:30431", "IIOD target host:port")
 	samples := flag.Uint64("samples", 4096, "Number of samples for OPEN")
-	mask := flag.String("mask", "1", "Channel mask in hex (e.g. 1 or 0x3)")
+	mask := flag.String("mask", "auto", "Channel mask in hex (e.g. 1 or 0x3) or 'auto' to derive from XML")
 	cyclic := flag.Bool("cyclic", false, "Request a cyclic buffer")
 	readBytes := flag.Int("bytes", 0, "Bytes to request via READBUF (default: samples)")
 	flag.Parse()
@@ -74,25 +106,53 @@ func main() {
 	}
 
 	log.Printf("[INFO] Fetching XML context from %s", m.Address)
-	xml, err := m.FetchXML()
+	rawXML, err := m.FetchXML()
 	if err != nil {
 		log.Fatalf("fetch XML failed: %v", err)
 	}
-	log.Printf("[INFO] Retrieved XML context (%d bytes)", len(xml))
-	if len(xml) > 0 {
-		preview := xml
+	log.Printf("[INFO] Retrieved XML context (%d bytes)", len(rawXML))
+	if len(rawXML) > 0 {
+		preview := rawXML
 		if len(preview) > 256 {
 			preview = preview[:256]
 		}
 		log.Printf("[INFO] XML preview: %q...", preview)
 	}
 
-	log.Printf("[INFO] Opening buffer: device=cf-ad9361-lpc samples=%d mask=%s cyclic=%v", *samples, *mask, *cyclic)
-	if err := m.OpenBufferASCII("cf-ad9361-lpc", *samples, *mask, *cyclic); err != nil {
+	// Prefer the device ID present in the XML (e.g. iio:device3) over the
+	// friendly name. Some IIOD servers only accept the ID for buffer
+	// commands, which would otherwise return EINVAL.
+	rxDevice := "cf-ad9361-lpc"
+	resolvedMask := strings.TrimSpace(*mask)
+
+	var ctx sdrxml.SDRContext
+	if err := ctx.Parse([]byte(rawXML)); err != nil {
+		log.Printf("[WARN] XML parse failed; continuing with defaults: %v", err)
+	} else if dev, err := ctx.Index.LookupDevice(rxDevice); err != nil {
+		log.Printf("[WARN] Unable to resolve %q from XML; continuing with defaults: %v", rxDevice, err)
+	} else {
+		if dev.ID != "" {
+			rxDevice = dev.ID
+			log.Printf("[INFO] Resolved rx device to ID %q", rxDevice)
+		}
+
+		if strings.EqualFold(resolvedMask, "auto") {
+			if autoMask, ok := deriveInputMask(dev); ok {
+				resolvedMask = autoMask
+				log.Printf("[INFO] Derived channel mask from XML: %s", resolvedMask)
+			} else {
+				log.Printf("[WARN] Unable to derive mask from XML; falling back to user mask=%s", *mask)
+				resolvedMask = *mask
+			}
+		}
+	}
+
+	log.Printf("[INFO] Opening buffer: device=%s samples=%d mask=%s cyclic=%v", rxDevice, *samples, resolvedMask, *cyclic)
+	if err := m.OpenBufferASCII(rxDevice, *samples, resolvedMask, *cyclic); err != nil {
 		log.Fatalf("open buffer failed: %v", err)
 	}
 	defer func() {
-		if err := m.CloseBufferASCII("cf-ad9361-lpc"); err != nil {
+		if err := m.CloseBufferASCII(rxDevice); err != nil {
 			log.Printf("[WARN] close buffer error: %v", err)
 		}
 	}()
@@ -104,7 +164,7 @@ func main() {
 	log.Printf("[INFO] Preparing READBUF request: bytes=%d (samples=%d)", requested, *samples)
 	buf := make([]byte, requested)
 
-	n, maskLine, err := m.ReadBufferASCIIWithMask("cf-ad9361-lpc", buf)
+	n, maskLine, err := m.ReadBufferASCIIWithMask(rxDevice, buf)
 	if err != nil {
 		log.Fatalf("read buffer failed: %v", err)
 	}


### PR DESCRIPTION
## Summary
- derive the RX channel mask from the XML context when requested and prefer the IIOD device ID over the friendly name
- add an XML-driven helper to build the input channel mask using scan-element indexes
- default the ASCII diagnostic flag to auto-mask derivation and propagate the resolved device ID through buffer operations
